### PR TITLE
Platform Optimization & Wireless PS3 Controller Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ endif
 ifeq ($(PLATFORM),)
 PLATFORM = rpi
 endif
+
 @echo Platform is $(PLATFORM)
 
 # set this the operating system you're building for
@@ -44,18 +45,6 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
 	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
-
-##ifeq ($(PLATFORM),rpi2)
-##CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard \
-	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant 
-##endif
-##ifeq ($(PLATFORM),rpi2)
-##CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
-	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant 
-##endif
-##CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
 
 LDFLAGS = $(CFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
-	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
+	-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
 
 LDFLAGS = $(CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I/usr/include/SDL \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
-        -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
+	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
 
 # Platform specific
 ifeq ($(PLATFORM),rpi2)
@@ -47,8 +47,8 @@ else
 CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard
 endif
 
-CFLAGS += -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
+CFLAGS += -O3 -ffast-math -fno-builtin -fsingle-precision-constant \
+	-fno-common -mstructure-size-boundary=32 -fweb -frename-registers \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
 
 LDFLAGS = $(CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -39,22 +39,17 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
         -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
-#       -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
-#       -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-#       -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
-#       -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
 
+# Platform specific
 ifeq ($(PLATFORM),rpi2)
-CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
-        -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-        -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 else
-CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard \
-        -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-        -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard
 endif
 
-CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
+CFLAGS += -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
+	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
 
 LDFLAGS = $(CFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,20 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
-	-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
+	-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
+	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
 
 ##ifeq ($(PLATFORM),rpi2)
-##CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+##CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard \
+	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant 
 ##endif
 ##ifeq ($(PLATFORM),rpi2)
-##CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+##CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
+	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant 
 ##endif
 ##CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@ TARGET = mame
 endif
 
 ifeq ($(PLATFORM),)
-PLATFORM = rpi
+PLATFORM = rpi1
 endif
-
-@echo Platform is $(PLATFORM)
 
 # set this the operating system you're building for
 # (actually you'll probably need your own main makefile anyways)
@@ -55,7 +53,7 @@ OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \
 	$(OBJ)/drivers $(OBJ)/machine $(OBJ)/vidhrdw $(OBJ)/sndhrdw \
 	$(OBJ)/zlib
 
-all:	maketree $(EMULATOR)
+all:    print-PLATFORM  maketree $(EMULATOR)
 
 # include the various .mak files
 include src/core.mak
@@ -95,3 +93,5 @@ maketree: $(sort $(OBJDIRS))
 clean:
 	$(RM) -r $(OBJ)
 	$(RM) $(EMULATOR)
+
+print-%: ; @echo $*=$($*)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ ifeq ($(TARGET),)
 TARGET = mame
 endif
 
+ifeq ($(PLATFORM),)
+PLATFORM = rpi
+endif
+@echo Platform is $(PLATFORM)
+
 # set this the operating system you're building for
 # (actually you'll probably need your own main makefile anyways)
 # MAMEOS = msdos
@@ -37,6 +42,14 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
 	-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
+
+##ifeq ($(PLATFORM),rpi2)
+##CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+##endif
+##ifeq ($(PLATFORM),rpi2)
+##CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+##endif
+##CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
 
 LDFLAGS = $(CFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 # set this the operating system you're building for
 # (actually you'll probably need your own main makefile anyways)
 # MAMEOS = msdos
-#MAMEOS = gp2x
+# MAMEOS = gp2x
 MAMEOS = rpi
 
 # extension for executables
@@ -38,11 +38,23 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I/usr/include/SDL \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
-	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
-	-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
-	-O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
-	-falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
-	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
+        -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
+#       -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
+#       -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+#       -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant \
+#       -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
+
+ifeq ($(PLATFORM),rpi2)
+CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
+        -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+        -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+else
+CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard \
+        -O3 -ffast-math -mstructure-size-boundary=32 -fweb -frename-registers \
+        -falign-functions=16 -fno-common -fno-builtin -fsingle-precision-constant
+endif
+
+CFLAGS += -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow
 
 LDFLAGS = $(CFLAGS)
 

--- a/src/rpi/minimal.cpp
+++ b/src/rpi/minimal.cpp
@@ -169,9 +169,9 @@ int init_SDL(void)
 				//Allow SDL badly handled axis like PS3
 				if (SDL_JoystickNumAxes(myjoy[i]) > 28)
 				{
-					SDL_JoystickClose(myjoy[i]);
-					myjoy[i]=0;
-					logerror("Error detected invalid joystick/keyboard\n");
+					logerror("Error detected invalid joystick/keyboard. Detected %d axis\n", SDL_JoystickNumAxes(myjoy[i]));
+					//SDL_JoystickClose(myjoy[i]);
+					//myjoy[i]=0;
 				}
 			}
 		}


### PR DESCRIPTION
Handle platform cpu specific CFlags. Re-added CFlags that were removed, but weren't covered by others. See: https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html & https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

Disable (again) the denial of high numbers of detected axis. Wireless PS3 controller appears to still go beyond this limit of 28 axis. Must have something to do with the Bluetooth drivers, since wired PS3 controller's don't have an issue. Improve error logging to show the number of axis detected.
