### PR TITLE
Update RPI EGL/GLES library names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -lpthread -lSDL -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lGLESv2 -lEGL -lglib-2.0 -lasound -lrt
+LIBS = -lm -lpthread -lSDL -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound -lrt
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile.debug
+++ b/Makefile.debug
@@ -46,7 +46,7 @@ CFLAGS = -g -fsigned-char $(DEVLIBS) \
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -L. -lm -lpthread -lSDL -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lGLESv2 -lEGL -lglib-2.0 -lasound -lrt
+LIBS = -L. -lm -lpthread -lSDL -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound -lrt
 
 OBJ = obj_$(TARGET)_$(MAMEOS)_debug
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \


### PR DESCRIPTION
Fixes build on stretch (and remains compatible with jessie).