### PR TITLE
Add -Wno-narrowing flag to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
 	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
-	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow 
+	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow \
+	-Wno-narrowing
 
 LDFLAGS = $(CFLAGS)
 

--- a/Makefile.debug
+++ b/Makefile.debug
@@ -42,7 +42,8 @@ CFLAGS = -g -fsigned-char $(DEVLIBS) \
 	-mstructure-size-boundary=32 -fexpensive-optimizations \
 	-fweb -frename-registers -falign-functions=16 -falign-loops -falign-labels -falign-jumps \
 	-finline -finline-functions -fno-common -fno-builtin -fsingle-precision-constant \
-	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow -Wwrite-strings
+	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow -Wwrite-strings \
+	-Wno-narrowing
 
 LDFLAGS = $(CFLAGS)
 


### PR DESCRIPTION
Necessary to allow building on stretch.

We could cherry-pick this commit instead, but it has merge conflicts that would need fixing: https://github.com/mamedev/mame/commit/2ce19e896bc9567ffe6d9e04eeddc2eacd30fa2d