### PR TITLE
added integer display option and blit optimizations

### DIFF
--- a/mame.cfg.template
+++ b/mame.cfg.template
@@ -23,6 +23,8 @@ force_stereo=no
 # Anti-alias the display?
 display_smooth_stretch=yes
 display_border=0
+# Do not fit and get pixel perfect (x1)
+display_integer=1
 # display effect postprocessing: 0 none, 1 scanlines
 display_effect=0
 

--- a/src/mame.h
+++ b/src/mame.h
@@ -105,6 +105,7 @@ struct GameOptions {
 	int display_border;
 	int display_smooth_stretch;
 	int display_effect;
+	int display_integer;
 };
 
 extern struct GameOptions options;

--- a/src/rpi/blit.cpp
+++ b/src/rpi/blit.cpp
@@ -39,7 +39,7 @@ void blitscreen_dirty1_color8(struct osd_bitmap *bitmap)
         }
         while (y); 
 
-    gp2x_video_flip(bitmap);
+    gp2x_video_flip();
 }
 
 void blitscreen_dirty0_color8(struct osd_bitmap *bitmap)
@@ -59,7 +59,7 @@ void blitscreen_dirty0_color8(struct osd_bitmap *bitmap)
         }
         while (y);  
 
-    gp2x_video_flip(bitmap);
+    gp2x_video_flip();
 }
 
 void blitscreen_dirty1_palettized16(struct osd_bitmap *bitmap)
@@ -100,7 +100,7 @@ void blitscreen_dirty1_palettized16(struct osd_bitmap *bitmap)
 		address += 16 * gfx_width;
 	}
 
-	gp2x_video_flip(bitmap);
+	gp2x_video_flip();
 }
 
 void blitscreen_dirty0_palettized16(struct osd_bitmap *bitmap)
@@ -121,7 +121,7 @@ void blitscreen_dirty0_palettized16(struct osd_bitmap *bitmap)
 		address+=gfx_width;
 	}
 	
-	gp2x_video_flip(bitmap);
+	gp2x_video_flip();
 }
 
 void blitscreen_dirty1_color16(struct osd_bitmap *bitmap)
@@ -162,7 +162,7 @@ void blitscreen_dirty1_color16(struct osd_bitmap *bitmap)
 		address += 16 * gfx_width;
 	}
 
-	gp2x_video_flip(bitmap);
+	gp2x_video_flip();
 }
 
 void blitscreen_dirty0_color16(struct osd_bitmap *bitmap)
@@ -183,5 +183,5 @@ void blitscreen_dirty0_color16(struct osd_bitmap *bitmap)
 		address+=gfx_width;
 	}
 	
-	gp2x_video_flip(bitmap);
+	gp2x_video_flip();
 }

--- a/src/rpi/config.cpp
+++ b/src/rpi/config.cpp
@@ -484,6 +484,7 @@ void parse_cmdline (int argc, char **argv, int game_index)
 	options.display_border = get_int ("config", "display_border", NULL, 24);
 	options.display_smooth_stretch = get_bool ("config", "display_smooth_stretch", NULL, 1);
 	options.display_effect = get_int ("config", "display_effect", NULL, 0);
+	options.display_integer = get_int  ("config", "display_integer",  NULL,  0);
 
 	kiosk_mode = get_bool("config", "kioskmode", NULL, 0);
 

--- a/src/rpi/minimal.cpp
+++ b/src/rpi/minimal.cpp
@@ -25,14 +25,9 @@ static int surface_height;
 
 #define MAX_SAMPLE_RATE (44100*2)
 
-void gp2x_video_flip(struct osd_bitmap *bitmap)
+void gp2x_video_flip(void)
 {
-    DisplayScreen(bitmap);
-}
-
-void gp2x_video_flip_single(struct osd_bitmap *bitmap)
-{
-    DisplayScreen(bitmap);
+    DisplayScreen();
 }
 
 extern void gles2_palette_changed();
@@ -226,7 +221,6 @@ static uint32_t display_adj_width, display_adj_height;		//display size minus bor
 void gp2x_set_video_mode(struct osd_bitmap *bitmap, int bpp,int width,int height)
 {
 
-	int ret;
 	uint32_t display_width, display_height, surface_size;
 	uint32_t display_x=0, display_y=0;
 	float display_ratio,game_ratio;
@@ -385,7 +379,7 @@ void gp2x_set_video_mode(struct osd_bitmap *bitmap, int bpp,int width,int height
 extern EGLDisplay display;
 extern EGLSurface surface;
 
-void update_throttle()
+void update_throttle(void)
 {
     // updated from video.cpp
 	extern int throttle;
@@ -402,7 +396,7 @@ void update_throttle()
 	}
 }
 
-void DisplayScreen(struct osd_bitmap *bitmap)
+void DisplayScreen(void)
 {
     //Draw to the screen
   	gles2_draw(rpi_screen, surface_width, surface_height);

--- a/src/rpi/minimal.h
+++ b/src/rpi/minimal.h
@@ -54,8 +54,7 @@ extern unsigned short 		*gp2x_screen15;
 extern void gp2x_init(int tickspersecond, int bpp, int rate, int bits, int stereo, int hz, int caller);
 extern void gp2x_deinit(void);
 extern void gp2x_timer_delay(unsigned long ticks);
-extern void gp2x_video_flip(struct osd_bitmap *bitmap);
-extern void gp2x_video_flip_single(void);
+extern void gp2x_video_flip(void);
 extern void gp2x_video_setpalette(void);
 extern void gp2x_joystick_clear(void);
 extern unsigned long gp2x_joystick_read(void);
@@ -69,7 +68,7 @@ extern void gp2x_printf_init(void);
 extern void gp2x_gamelist_text_out(int x, int y, char *eltexto, int color);
 extern void gp2x_gamelist_text_out_fmt(int x, int y, char* fmt, ...);
 
-extern void DisplayScreen(struct osd_bitmap *bitmap);
+extern void DisplayScreen();
 extern void FE_DisplayScreen(void);
 
 extern void gp2x_frontend_init(void);
@@ -78,7 +77,7 @@ extern void gp2x_frontend_deinit(void);
 extern void deinit_SDL(void);
 extern int init_SDL(void);
 
-void update_throttle();
+void update_throttle(void);
 
 // gl config on boot
 void gles2_draw_8(void *screen, int width, int height);

--- a/src/rpi/minimal.h
+++ b/src/rpi/minimal.h
@@ -78,4 +78,10 @@ extern void gp2x_frontend_deinit(void);
 extern void deinit_SDL(void);
 extern int init_SDL(void);
 
+void update_throttle();
+
+// gl config on boot
+void gles2_draw_8(void *screen, int width, int height);
+void gles2_draw_16(void *screen, int width, int height);
+
 #endif

--- a/src/rpi/video.cpp
+++ b/src/rpi/video.cpp
@@ -1076,6 +1076,7 @@ void osd_update_video_and_audio(struct osd_bitmap *bitmap)
 	if (input_ui_pressed(IPT_UI_THROTTLE))
 	{
 		throttle ^= 1;
+		update_throttle();
 	}
 
 	frameskip_counter = (frameskip_counter + 1) % FRAMESKIP_LEVELS;


### PR DESCRIPTION
Hello, 
I created a new option to enable a pixel perfect display mode, very useful for lcd displays (like GPI).
another PR with same feature added to pisnes: https://github.com/RetroPie/pisnes/pull/8

![imagen](https://user-images.githubusercontent.com/560310/63923665-38721480-ca47-11e9-9e9f-a6bf06ddc6b7.png)

I added some optimizations to the draw functions, thanks :+1: 