### PR TITLE
Allow cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,15 @@ ifeq ($(HAS_PKGCONF),yes)
   SDL_LIBS ?= $(shell $(PKGCONF) --libs sdl)
   VCSM_CFLAGS ?= $(shell $(PKGCONF) --cflags vcsm)
   VCSM_LIBS ?= $(shell $(PKGCONF) --libs vcsm)
+  EGL_CFLAGS ?= $(shell $(PKGCONF) --cflags egl)
+  EGL_LIBS ?= $(shell $(PKGCONF) --libs egl)
 else
   SDL_CFLAGS ?= -I/usr/include/SDL
   SDL_LIBS ?= -lSDL
   VCSM_CFLAGS ?= -I$(SDKSTAGE)/opt/vc/include
   VCSM_LIBS ?= -L$(SDKSTAGE)/opt/vc/lib
+  EGL_CFLAGS ?= -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads -I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux
+  EGL_LIBS ?= -lbcm_host -lbrcmGLESv2 -lbrcmEGL
 endif
 
 
@@ -48,8 +52,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	-Isrc -Isrc/$(MAMEOS) -Isrc/zlib \
 	$(SDL_CFLAGS) \
 	$(VCSM_CFLAGS) \
-	-I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
-	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
+	$(EGL_CFLAGS) \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
 	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow \
@@ -57,7 +60,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound
+LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) $(EGL_LIBS) -lglib-2.0 -lasound
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,27 @@ CC  ?= $(CROSS_COMPILE)gcc
 CXX ?= $(CROSS_COMPILE)g++
 AS  ?= $(CROSS_COMPILE)as
 STRIP ?= $(CROSS_COMPILE)strip
+PKGCONF ?= pkg-config
 
 EMULATOR = $(TARGET)$(EXE)
 
 DEFS = -DGP2X -DLSB_FIRST -DALIGN_INTS -DALIGN_SHORTS -DINLINE="static __inline" -Dasm="__asm__ __volatile__" -DMAME_UNDERCLOCK -DENABLE_AUTOFIRE -DBIGCASE
 ##sq DEFS = -DGP2X -DLSB_FIRST -DALIGN_INTS -DALIGN_SHORTS -DINLINE="static __inline" -Dasm="__asm__ __volatile__" -DMAME_UNDERCLOCK -DMAME_FASTSOUND -DENABLE_AUTOFIRE -DBIGCASE
 
+HAS_PKGCONF := $(if $(shell which $(PKGCONF)),yes,no)
+
+ifeq ($(HAS_PKGCONF),yes)
+  SDL_CFLAGS ?= $(shell $(PKGCONF) --cflags sdl)
+  SDL_LIBS ?= $(shell $(PKGCONF) --libs sdl)
+else
+  SDL_CFLAGS ?= -I/usr/include/SDL
+  SDL_LIBS ?= -lSDL
+endif
+
+
 CFLAGS += -fsigned-char $(DEVLIBS) \
 	-Isrc -Isrc/$(MAMEOS) -Isrc/zlib \
-	-I/usr/include/SDL \
+	$(SDL_CFLAGS) \
 	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
@@ -40,7 +52,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -lpthread -lSDL -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound -lrt
+LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,21 @@ HAS_PKGCONF := $(if $(shell which $(PKGCONF)),yes,no)
 ifeq ($(HAS_PKGCONF),yes)
   SDL_CFLAGS ?= $(shell $(PKGCONF) --cflags sdl)
   SDL_LIBS ?= $(shell $(PKGCONF) --libs sdl)
+  VCSM_CFLAGS ?= $(shell $(PKGCONF) --cflags vcsm)
+  VCSM_LIBS ?= $(shell $(PKGCONF) --libs vcsm)
 else
   SDL_CFLAGS ?= -I/usr/include/SDL
   SDL_LIBS ?= -lSDL
+  VCSM_CFLAGS ?= -I$(SDKSTAGE)/opt/vc/include
+  VCSM_LIBS ?= -L$(SDKSTAGE)/opt/vc/lib
 endif
 
 
 CFLAGS += -fsigned-char $(DEVLIBS) \
 	-Isrc -Isrc/$(MAMEOS) -Isrc/zlib \
 	$(SDL_CFLAGS) \
-	-I$(SDKSTAGE)/opt/vc/include -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
+	$(VCSM_CFLAGS) \
+	-I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads \
 	-I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux \
 	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
 	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
@@ -52,7 +57,7 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) -L$(SDKSTAGE)/opt/vc/lib -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound
+LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) -lbcm_host -lbrcmGLESv2 -lbrcmEGL -lglib-2.0 -lasound
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ VPATH=src $(wildcard src/cpu/*)
 # compiler, linker and utilities
 MD = @mkdir -p
 RM = rm -f
-CC  = gcc
-CPP = g++
-AS  = as
-STRIP = strip
+CC  ?= $(CROSS_COMPILE)gcc
+CXX ?= $(CROSS_COMPILE)g++
+AS  ?= $(CROSS_COMPILE)as
+STRIP ?= $(CROSS_COMPILE)strip
 
 EMULATOR = $(TARGET)$(EXE)
 
@@ -71,15 +71,15 @@ $(OBJ)/%.o: src/%.c
 
 $(OBJ)/%.o: src/%.cpp
 	@echo Compiling $<...
-	$(CPP) $(CDEFS) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CXX) $(CDEFS) $(CFLAGS) -fno-rtti -c $< -o $@
 
 $(OBJ)/%.o: src/%.s
 	@echo Compiling $<...
-	$(CPP) $(CDEFS) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CDEFS) $(CFLAGS) -c $< -o $@
 
 $(OBJ)/%.o: src/%.S
 	@echo Compiling $<...
-	$(CPP) $(CDEFS) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CDEFS) $(CFLAGS) -c $< -o $@
 
 $(sort $(OBJDIRS)):
 	$(MD) $@

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ RM = rm -f
 CC  = gcc
 CPP = g++
 AS  = as
-LD  = gcc
 STRIP = strip
 
 EMULATOR = $(TARGET)$(EXE)
@@ -61,7 +60,7 @@ include src/$(MAMEOS)/$(MAMEOS).mak
 CDEFS = $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS)
 
 $(EMULATOR): $(COREOBJS) $(OSOBJS) $(DRVOBJS)
-	$(LD) $(LDFLAGS) $(COREOBJS) $(OSOBJS) $(LIBS) $(DRVOBJS) -o $@
+	$(CC) $(LDFLAGS) $(COREOBJS) $(OSOBJS) $(LIBS) $(DRVOBJS) -o $@
 	$(STRIP) $(EMULATOR)	
 
 $(OBJ)/%.o: src/%.c

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ ifeq ($(HAS_PKGCONF),yes)
   VCSM_LIBS ?= $(shell $(PKGCONF) --libs vcsm)
   EGL_CFLAGS ?= $(shell $(PKGCONF) --cflags egl)
   EGL_LIBS ?= $(shell $(PKGCONF) --libs egl)
+  GLIB_CFLAGS ?= $(shell $(PKGCONF) --cflags glib-2.0)
+  GLIB_LIBS ?= $(shell $(PKGCONF) --libs glib-2.0)
 else
   SDL_CFLAGS ?= -I/usr/include/SDL
   SDL_LIBS ?= -lSDL
@@ -45,6 +47,8 @@ else
   VCSM_LIBS ?= -L$(SDKSTAGE)/opt/vc/lib
   EGL_CFLAGS ?= -I$(SDKSTAGE)/opt/vc/include/interface/vcos/pthreads -I$(SDKSTAGE)/opt/vc/include/interface/vmcs_host/linux
   EGL_LIBS ?= -lbcm_host -lbrcmGLESv2 -lbrcmEGL
+  GLIB_CFLAGS ?= -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
+  GLIB_LIBS ?= -lglib-2.0
 endif
 
 
@@ -53,14 +57,14 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	$(SDL_CFLAGS) \
 	$(VCSM_CFLAGS) \
 	$(EGL_CFLAGS) \
-	-I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include \
+	$(GLIB_CFLAGS) \
 	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow \
 	-Wno-narrowing
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) $(EGL_LIBS) -lglib-2.0 -lasound
+LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) $(EGL_LIBS) $(GLIB_LIBS) -lasound
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ ifeq ($(HAS_PKGCONF),yes)
   EGL_LIBS ?= $(shell $(PKGCONF) --libs egl)
   GLIB_CFLAGS ?= $(shell $(PKGCONF) --cflags glib-2.0)
   GLIB_LIBS ?= $(shell $(PKGCONF) --libs glib-2.0)
+  ALSA_CFLAGS ?= $(shell $(PKGCONF) --cflags alsa)
+  ALSA_LIBS ?= $(shell $(PKGCONF) --libs alsa)
 else
   SDL_CFLAGS ?= -I/usr/include/SDL
   SDL_LIBS ?= -lSDL
@@ -49,6 +51,8 @@ else
   EGL_LIBS ?= -lbcm_host -lbrcmGLESv2 -lbrcmEGL
   GLIB_CFLAGS ?= -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include
   GLIB_LIBS ?= -lglib-2.0
+  ALSA_CFLAGS ?=
+  ALSA_LIBS ?= -lasound
 endif
 
 
@@ -58,13 +62,14 @@ CFLAGS += -fsigned-char $(DEVLIBS) \
 	$(VCSM_CFLAGS) \
 	$(EGL_CFLAGS) \
 	$(GLIB_CFLAGS) \
+	$(ALSA_CFLAGS) \
 	-O3 -ffast-math -fno-builtin -fsingle-precision-constant \
 	-Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wcast-align -Waggregate-return -Wshadow \
 	-Wno-narrowing
 
 LDFLAGS = $(CFLAGS)
 
-LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) $(EGL_LIBS) $(GLIB_LIBS) -lasound
+LIBS = -lm -ldl -lpthread -lrt $(SDL_LIBS) $(VCSM_LIBS) $(EGL_LIBS) $(GLIB_LIBS) $(ALSA_LIBS)
 
 OBJ = obj_$(TARGET)_$(MAMEOS)
 OBJDIRS = $(OBJ) $(OBJ)/cpu $(OBJ)/sound $(OBJ)/$(MAMEOS) \

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ include src/$(MAMEOS)/$(MAMEOS).mak
 # combine the various definitions to one
 CDEFS = $(DEFS) $(COREDEFS) $(CPUDEFS) $(SOUNDDEFS)
 
-$(EMULATOR): $(COREOBJS) $(OSOBJS) $(DRVOBJS)
+$(EMULATOR): $(OBJ)/$(EMULATOR)
+	$(STRIP) -o $@ $<
+
+$(OBJ)/$(EMULATOR): $(COREOBJS) $(OSOBJS) $(DRVOBJS)
 	$(CC) $(LDFLAGS) $(COREOBJS) $(OSOBJS) $(LIBS) $(DRVOBJS) -o $@
-	$(STRIP) $(EMULATOR)	
 
 $(OBJ)/%.o: src/%.c
 	@echo Compiling $<...


### PR DESCRIPTION
I modified the mame4all-pi build scripts to allow for cross-compilation. This was needed in my case, as that I used Buildroot to construct a custom MAME system.

Caution: I have not tried these changes on Raspbian. For someone using Raspbian, please check if my changes results in a still working mame binary, prior to accepting my pull request.